### PR TITLE
feat: minor release v3.3.0; adds new backup capabilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -834,7 +834,9 @@ The real return on investment often comes from time gains and the reliability of
 | EFS Storage | 100GB | $30          | N/A |
 | NAT Gateway | 3 gateway (static cost; add $0.045 price per GB processed) | $99          | N/A |
 | WAFv2 | 5 rules + 1 ACL | $10          | N/A |
-| **Total** | | **$385**     | |
+| AWS Backup | 200 GB backup size (first month) | $18          | N/A |
+| KMS Keys | 7 keys (EKS, EFS, RDS, ElastiCache, S3, CloudWatch, Backup) | $7          | N/A |
+| **Total** | | **$410**     | |
 
 ### **Mid-Size Hospital (average 100s of users concurrently) (thousands of patients served)**
 
@@ -847,7 +849,9 @@ The real return on investment often comes from time gains and the reliability of
 | EFS Storage | 500GB | $150         | N/A |
 | NAT Gateway | 3 gateway (static cost; add $0.045 price per GB processed) | $99          | N/A |
 | WAFv2 | 5 rules + 1 ACL | $10          | N/A |
-| **Total** | | **$816**     | |
+| AWS Backup | 500 GB backup size (first month) | $40          | N/A |
+| KMS Keys | 7 keys (EKS, EFS, RDS, ElastiCache, S3, CloudWatch, Backup) | $7          | N/A |
+| **Total** | | **$863**     | |
 
 ### **Large Hospital (average 1000s of users concurrently) (millions of patients served)**
 
@@ -856,11 +860,13 @@ The real return on investment often comes from time gains and the reliability of
 | EKS Control Plane | 1 cluster | $73          | N/A |
 | EC2 Compute (Auto Mode) | ~8 m5.xlarge equiv. ($0.192/hr) | $1,121       | $135 |
 | Aurora Serverless V2 | 0.5-16 ACUs (AVG of 6 ACU) | $522         | N/A |
-| Valkey Serverless | 1GB (AVG data stored; mostly user sessions), 6000 ECPUs | $76         | N/A |
+| Valkey Serverless | 1GB (AVG data stored; mostly user sessions), 6000 ECPUs | $76          | N/A |
 | EFS Storage | 2TB | $600         | N/A |
-| NAT Gateway | 3 gateways (static cost; add $0.045 price per GB processed) | $99         | N/A |
+| NAT Gateway | 3 gateways (static cost; add $0.045 price per GB processed) | $99          | N/A |
 | WAFv2 | 5 rules + 1 ACL | $10          | N/A |
-| **Total** | | **$2636**   | |
+| AWS Backup | 900 GB backup size (first month) | $75          | N/A |
+| KMS Keys | 7 keys (EKS, EFS, RDS, ElastiCache, S3, CloudWatch, Backup) | $7           | N/A |
+| **Total** | | **$2718**    | |
 
 ### Pricing Documentation
 
@@ -879,6 +885,8 @@ The real return on investment often comes from time gains and the reliability of
   - [Amazon VPC/NAT Gateway Pricing](https://aws.amazon.com/vpc/pricing/)
 - Web Application Security Pricing
   - [AWS WAF Pricing](https://aws.amazon.com/waf/pricing/)
+- Backup & Recovery Pricing
+  - [AWS Backup Pricing](https://aws.amazon.com/backup/pricing/)
 
 ### **🔒 WAFv2 Pricing Breakdown**
 

--- a/scripts/restore.sh
+++ b/scripts/restore.sh
@@ -65,7 +65,7 @@ readonly EFS_PROPAGATION_WAIT=${EFS_PROPAGATION_WAIT:-30}                 # 30 s
 readonly HEALTH_CHECK_INTERVAL=${HEALTH_CHECK_INTERVAL:-10}               # 10 seconds
 readonly VERIFICATION_TIMEOUT=${VERIFICATION_TIMEOUT:-300}                # 5 minutes for final verification
 readonly VERIFICATION_INTERVAL=${VERIFICATION_INTERVAL:-10}               # 10 seconds between verification checks
-readonly VERIFICATION_MAX_ATTEMPTS=${VERIFICATION_MAX_ATTEMPTS:-3}        # 3 attempts with crypto key cleanup retry
+readonly VERIFICATION_MAX_ATTEMPTS=${VERIFICATION_MAX_ATTEMPTS:-6}        # 6 attempts with crypto key cleanup retry
 
 # Temp pod resource configuration
 readonly TEMP_POD_MEMORY_REQUEST=${TEMP_POD_MEMORY_REQUEST:-1Gi}         # Memory request

--- a/terraform/backup.tf
+++ b/terraform/backup.tf
@@ -1,0 +1,330 @@
+# =============================================================================
+# AWS BACKUP CONFIGURATION
+# =============================================================================
+# This configuration creates a comprehensive AWS Backup setup for automatic
+# backups of all critical infrastructure components with encryption, retention
+# policies, and scheduled backup plans.
+#
+# AWS Backup provides centralized backup management for:
+# - S3 buckets (ALB logs, WAF logs, Loki storage, CloudTrail logs)
+# - EFS file systems (application data and configuration)
+# - RDS Aurora clusters (database snapshots)
+# - EKS clusters (using AWS Backup support for EKS)
+#
+# Encryption: All backups are encrypted using a dedicated KMS key defined in
+# kms.tf (aws_kms_key.backup). This key has a custom policy to allow AWS Backup
+# service access for encryption operations.
+#
+# Reference: https://docs.aws.amazon.com/prescriptive-guidance/latest/backup-recovery/aws-backup.html
+
+# =============================================================================
+# DATA SOURCES FOR AWS BACKUP
+# =============================================================================
+# Data sources retrieve information from existing AWS resources for use in
+# backup configurations.
+
+# Get EKS cluster ARN for backup selection
+# The EKS cluster ARN is required for AWS Backup to identify the cluster
+data "aws_eks_cluster" "openemr" {
+  name       = var.cluster_name
+  depends_on = [module.eks]
+}
+
+# =============================================================================
+# AWS BACKUP VAULT
+# =============================================================================
+# Backup vault provides a centralized location for storing and organizing backups
+# with encryption, access control, and backup plan associations.
+
+# AWS Backup Vault - Centralized storage for all backups
+# Uses global suffix for uniqueness (backup vault names must be unique within account/region)
+resource "aws_backup_vault" "openemr" {
+  name        = "${var.cluster_name}-backup-vault-${random_id.global_suffix.hex}" # Backup vault name with global suffix
+  kms_key_arn = aws_kms_key.backup.arn                                            # KMS key for encryption
+
+  tags = {
+    Name        = "${var.cluster_name}-backup-vault"
+    Purpose     = "AWS Backup Storage"
+    Environment = var.environment
+  }
+}
+
+# =============================================================================
+# AWS BACKUP PLANS
+# =============================================================================
+# Backup plans define when backups are created and how long they are retained.
+# Three backup plans are created:
+# - Daily: Frequent backups for recent recovery needs (EFS backup transitioned to cold storage after 30 days)
+# - Weekly: Weekly backups for intermediate recovery needs (EFS backup transitioned to cold storage after 60 days)
+# - Monthly: Monthly backups for long-term retention (EFS backup transitioned to cold storage after 90 days)
+# All of these plans create backups that last 7 years by default.
+# You can alter the retention of each of these plans individually by changing "2555" to a number of days you'd prefer.
+
+# Daily Backup Plan - Creates backups every day
+# Uses global suffix for uniqueness and consistency with other resources
+resource "aws_backup_plan" "daily" {
+  name = "${var.cluster_name}-backup-plan-daily-${random_id.global_suffix.hex}"
+
+  # Daily backup rule - runs every day at 2:00 AM UTC
+  rule {
+    rule_name                = "daily-backup-rule"
+    target_vault_name        = aws_backup_vault.openemr.name
+    schedule                 = "cron(0 2 * * ? *)" # Daily at 2:00 AM UTC
+    enable_continuous_backup = false
+
+    # Lifecycle configuration - transition to cold storage after 30 days, delete after 7 years
+    lifecycle {
+      cold_storage_after = 30   # Move to cold storage after 30 days
+      delete_after       = 2555 # Delete after 7 years (365 * 7 = 2555 days)
+    }
+
+    # Recovery point tags for backup organization
+    recovery_point_tags = {
+      BackupPlan  = "daily"
+      Environment = var.environment
+      ManagedBy   = "Terraform"
+    }
+  }
+
+  tags = {
+    Name        = "${var.cluster_name}-backup-plan-daily"
+    Purpose     = "Daily Backups"
+    Environment = var.environment
+  }
+}
+
+# Weekly Backup Plan - Creates backups every week
+# Uses global suffix for uniqueness and consistency with other resources
+resource "aws_backup_plan" "weekly" {
+  name = "${var.cluster_name}-backup-plan-weekly-${random_id.global_suffix.hex}"
+
+  # Weekly backup rule - runs every Sunday at 3:00 AM UTC
+  rule {
+    rule_name                = "weekly-backup-rule"
+    target_vault_name        = aws_backup_vault.openemr.name
+    schedule                 = "cron(0 3 ? * SUN *)" # Weekly on Sunday at 3:00 AM UTC
+    enable_continuous_backup = false
+
+    # Lifecycle configuration - transition to cold storage after 90 days, delete after 7 years
+    lifecycle {
+      cold_storage_after = 90   # Move to cold storage after 90 days
+      delete_after       = 2555 # Delete after 7 years
+    }
+
+    # Recovery point tags for backup organization
+    recovery_point_tags = {
+      BackupPlan  = "weekly"
+      Environment = var.environment
+      ManagedBy   = "Terraform"
+    }
+  }
+
+  tags = {
+    Name        = "${var.cluster_name}-backup-plan-weekly"
+    Purpose     = "Weekly Backups"
+    Environment = var.environment
+  }
+}
+
+# Monthly Backup Plan - Creates backups every month
+# Uses global suffix for uniqueness and consistency with other resources
+resource "aws_backup_plan" "monthly" {
+  name = "${var.cluster_name}-backup-plan-monthly-${random_id.global_suffix.hex}"
+
+  # Monthly backup rule - runs on the first day of each month at 4:00 AM UTC
+  rule {
+    rule_name                = "monthly-backup-rule"
+    target_vault_name        = aws_backup_vault.openemr.name
+    schedule                 = "cron(0 4 1 * ? *)" # Monthly on the 1st at 4:00 AM UTC
+    enable_continuous_backup = false
+
+    # Lifecycle configuration - transition to cold storage after 180 days, delete after 7 years
+    lifecycle {
+      cold_storage_after = 180  # Move to cold storage after 180 days
+      delete_after       = 2555 # Delete after 7 years
+    }
+
+    # Recovery point tags for backup organization
+    recovery_point_tags = {
+      BackupPlan  = "monthly"
+      Environment = var.environment
+      ManagedBy   = "Terraform"
+    }
+  }
+
+  tags = {
+    Name        = "${var.cluster_name}-backup-plan-monthly"
+    Purpose     = "Monthly Backups"
+    Environment = var.environment
+  }
+}
+
+# =============================================================================
+# AWS BACKUP SELECTIONS
+# =============================================================================
+# Backup selections define which resources are backed up by each backup plan.
+# Resources are explicitly selected using resource ARNs to ensure all critical
+# resources are included in the backup plans.
+
+# Daily Backup Selection - Selects all critical resources for daily backups
+# Uses global suffix for uniqueness and consistency with other resources
+resource "aws_backup_selection" "daily" {
+  name         = "${var.cluster_name}-backup-selection-daily-${random_id.global_suffix.hex}"
+  iam_role_arn = aws_iam_role.backup.arn
+  plan_id      = aws_backup_plan.daily.id
+
+  # Resources to backup - all S3 buckets, EFS, RDS, and EKS
+  # Note: We explicitly list resources here instead of using tags
+  # to ensure all critical resources are backed up
+  resources = concat(
+    # S3 buckets
+    [
+      aws_s3_bucket.alb_logs.arn,
+      aws_s3_bucket.loki_storage.arn,
+      aws_s3_bucket.cloudtrail.arn
+    ],
+    # Conditionally include WAF logs bucket if WAF is enabled
+    var.enable_waf ? [aws_s3_bucket.waf_logs[0].arn] : [],
+    # EFS file system
+    [aws_efs_file_system.openemr.arn],
+    # RDS cluster
+    [aws_rds_cluster.openemr.arn],
+    # EKS cluster
+    [data.aws_eks_cluster.openemr.arn]
+  )
+}
+
+# Weekly Backup Selection - Selects all critical resources for weekly backups
+# Uses global suffix for uniqueness and consistency with other resources
+resource "aws_backup_selection" "weekly" {
+  name         = "${var.cluster_name}-backup-selection-weekly-${random_id.global_suffix.hex}"
+  iam_role_arn = aws_iam_role.backup.arn
+  plan_id      = aws_backup_plan.weekly.id
+
+  # Resources to backup - same as daily
+  # Note: We explicitly list resources here instead of using tags
+  # to ensure all critical resources are backed up
+  resources = concat(
+    # S3 buckets
+    [
+      aws_s3_bucket.alb_logs.arn,
+      aws_s3_bucket.loki_storage.arn,
+      aws_s3_bucket.cloudtrail.arn
+    ],
+    # Conditionally include WAF logs bucket if WAF is enabled
+    var.enable_waf ? [aws_s3_bucket.waf_logs[0].arn] : [],
+    # EFS file system
+    [aws_efs_file_system.openemr.arn],
+    # RDS cluster
+    [aws_rds_cluster.openemr.arn],
+    # EKS cluster
+    [data.aws_eks_cluster.openemr.arn]
+  )
+}
+
+# Monthly Backup Selection - Selects all critical resources for monthly backups
+# Uses global suffix for uniqueness and consistency with other resources
+resource "aws_backup_selection" "monthly" {
+  name         = "${var.cluster_name}-backup-selection-monthly-${random_id.global_suffix.hex}"
+  iam_role_arn = aws_iam_role.backup.arn
+  plan_id      = aws_backup_plan.monthly.id
+
+  # Resources to backup - same as daily and weekly
+  # Note: We explicitly list resources here instead of using tags
+  # to ensure all critical resources are backed up
+  resources = concat(
+    # S3 buckets
+    [
+      aws_s3_bucket.alb_logs.arn,
+      aws_s3_bucket.loki_storage.arn,
+      aws_s3_bucket.cloudtrail.arn
+    ],
+    # Conditionally include WAF logs bucket if WAF is enabled
+    var.enable_waf ? [aws_s3_bucket.waf_logs[0].arn] : [],
+    # EFS file system
+    [aws_efs_file_system.openemr.arn],
+    # RDS cluster
+    [aws_rds_cluster.openemr.arn],
+    # EKS cluster
+    [data.aws_eks_cluster.openemr.arn]
+  )
+}
+
+# =============================================================================
+# IAM ROLE FOR AWS BACKUP
+# =============================================================================
+# IAM role that AWS Backup uses to perform backup and restore operations.
+# This role must have permissions to access the resources being backed up.
+
+# IAM Role for AWS Backup - Service role for backup operations
+# Uses global suffix for uniqueness (IAM role names must be unique within AWS account)
+resource "aws_iam_role" "backup" {
+  name        = "${var.cluster_name}-backup-role-${random_id.global_suffix.hex}"
+  description = "IAM role for AWS Backup to perform backup and restore operations"
+
+  # Trust policy allowing AWS Backup service to assume this role
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Principal = {
+          Service = "backup.amazonaws.com"
+        }
+        Action = "sts:AssumeRole"
+        # Condition restricts access to current account
+        Condition = {
+          StringEquals = {
+            "aws:SourceAccount" = "${data.aws_caller_identity.current.account_id}"
+          }
+        }
+      }
+    ]
+  })
+
+  tags = {
+    Name        = "${var.cluster_name}-backup-role"
+    Purpose     = "AWS Backup Service Role"
+    Environment = var.environment
+  }
+}
+
+# Attach AWS managed policy for AWS Backup service role
+# This policy provides the necessary permissions for AWS Backup operations
+resource "aws_iam_role_policy_attachment" "backup" {
+  role       = aws_iam_role.backup.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSBackupServiceRolePolicyForBackup"
+}
+
+# Attach AWS managed policy for AWS Backup restore operations
+# This policy provides the necessary permissions for restore operations
+resource "aws_iam_role_policy_attachment" "backup_restore" {
+  role       = aws_iam_role.backup.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSBackupServiceRolePolicyForRestores"
+}
+
+# Additional IAM policy for EKS backup permissions
+# EKS backup requires additional permissions beyond the standard backup policies
+# Uses global suffix for uniqueness (IAM policy names must be unique within AWS account)
+resource "aws_iam_role_policy" "backup_eks" {
+  name = "${var.cluster_name}-backup-eks-policy-${random_id.global_suffix.hex}"
+  role = aws_iam_role.backup.id
+
+  # Policy document for EKS backup permissions
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "eks:DescribeCluster",
+          "eks:ListClusters",
+          "eks:DescribeNodegroup",
+          "eks:ListNodegroups"
+        ]
+        Resource = data.aws_eks_cluster.openemr.arn
+      }
+    ]
+  })
+}
+

--- a/terraform/eks.tf
+++ b/terraform/eks.tf
@@ -123,7 +123,7 @@ resource "time_sleep" "wait_for_compute" {
 resource "aws_eks_addon" "metrics_server" {
   cluster_name                = module.eks.cluster_name
   addon_name                  = "metrics-server"    # Essential for autoscaling
-  addon_version               = "v0.8.0-eksbuild.2" # Stable version for Kubernetes 1.34
+  addon_version               = "v0.8.0-eksbuild.3" # Latest stable version for Kubernetes 1.34
   resolve_conflicts_on_create = "OVERWRITE"         # Overwrite any existing conflicts
   resolve_conflicts_on_update = "OVERWRITE"         # Overwrite any existing conflicts
 

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -266,3 +266,47 @@ output "waf_enabled" {
   description = "Whether WAF is enabled"
   value       = var.enable_waf
 }
+
+# AWS Backup Configuration Outputs
+# These outputs expose key information about the AWS Backup configuration
+# that provides centralized backup management for all infrastructure components.
+
+output "backup_vault_name" {
+  description = "Name of the AWS Backup vault"
+  value       = aws_backup_vault.openemr.name
+}
+
+output "backup_vault_arn" {
+  description = "ARN of the AWS Backup vault"
+  value       = aws_backup_vault.openemr.arn
+}
+
+output "backup_kms_key_id" {
+  description = "ID of the KMS key used for AWS Backup encryption"
+  value       = aws_kms_key.backup.key_id
+}
+
+output "backup_kms_key_arn" {
+  description = "ARN of the KMS key used for AWS Backup encryption"
+  value       = aws_kms_key.backup.arn
+}
+
+output "backup_plan_daily_id" {
+  description = "ID of the daily backup plan"
+  value       = aws_backup_plan.daily.id
+}
+
+output "backup_plan_weekly_id" {
+  description = "ID of the weekly backup plan"
+  value       = aws_backup_plan.weekly.id
+}
+
+output "backup_plan_monthly_id" {
+  description = "ID of the monthly backup plan"
+  value       = aws_backup_plan.monthly.id
+}
+
+output "backup_role_arn" {
+  description = "ARN of the IAM role used by AWS Backup"
+  value       = aws_iam_role.backup.arn
+}

--- a/versions.yaml
+++ b/versions.yaml
@@ -56,7 +56,7 @@ eks_addons:
     description: "EFS CSI Driver for persistent storage"
 
   metrics_server:
-    current: "v0.8.0-eksbuild.2"
+    current: "v0.8.0-eksbuild.3"
     notify_on_update: true
     requires_aws_cli: true
     aws_addon_name: "metrics-server"


### PR DESCRIPTION
This PR adds:
- AWS Backup integration for all critical infrastructure (S3 buckets for CloudTrail, Grafana Loki, WAF, and ALB logs and EFS, EKS, and RDS).
-  Daily (at 2 AM UTC), weekly (at 3 AM UTC) and monthly (at 4 AM UTC) backup jobs that run independently of one another that are retained for 7 years.
- Adds backup.tf that defines the AWS Backup Vault for our deployment.
- Add a new dedicated KMS key for use with AWS Backup (total # of KMS keys 6 -> 7)
- Adds new terraform outputs for AWS Backup
- Improved destroy.sh to handle cases where there might be pending backup jobs or the vault might have recovery points.
- General improvements to destroy.sh
- Adds guards against failure modes where certain terraform show operations fail when the terraform state is partially or wholly deleted and/or corrupted
- Also adds more descriptive error handling and instructions for remediation for things like when the script fails because there’s no AWS credentials configured in the environment
- Changed the default number of verification attempts from 3 to 6 in restore.sh. This was done because in testing it was observed that while the verification almost always succeeded on the first attempt occasionally due to pod churn sometimes the verification takes two attempts. It’s never been observed in the many many runs it’s been through to ever need more than 2 attempts but just out of an abundance of caution I’ve decided to preemptively raise the number of attempts to 6 to guard against some statistically unlikely event that may or may not occur in the future while testing.
- Updated test-end-to-end-backup-restore.sh to use the destroy.sh script for the final destruction of infrastructure undertaken in the last step of the test.
- Previously this was accomplished through custom code which did pretty much the same thing as the destroy.sh script but it made little sense to keep maintaining this long term when the end to end test already uses the destroy.sh script earlier on for the initial destruction of infrastructure taken halfway through the test.
- Furthermore we should use the destroy script because it contains logic for handling the delete of the AWS Backup vault irregardless of what state the vault is in.
- Doing this guards against a potential failure mode where someone runs the end to end test too close to 2 AM UTC when the automated backup job goes off and then the terraform destroy would fail because the AWS Backup vault would have recovery points in it and or a pending backup job associated with it.
- Updated documentation to reflect the new functionality added in this PR.
- Also updates the version of the metrics server addon used by EKS

Overall this new backup capability provides the ability for users to do point in time recovery operations for specific components of the architecture at any time (i.e. restore only the EKS cluster to the state it was at this point in time, restore both the EKS cluster and the RDS to the state it was at this point in time, restore only the EFS to the state it was at this point in time, etc. etc.).  It also provides coverage, for the first time, to the four different s3 buckets we use for …
- CloudTrail events which audits AWS events in our accounts so we can analyze them to determine if anything undesired is occurring in our account,
- Application and node health logs stored in S3 via Grafana & Loki and scraped from our OpenEMR containers in real-time by Fluent Bit 4.1.1
- AWS Web Application Firewall events/logs (useful in the event there’s attempted cyberattacks or DDOS attacks or things to that affect; WAF would be our first line of defense in that case and should produce logs that indicated that something like that occurred and whether or not it was successful in mitigating the attack)
- AWS application load balancer logs showing network activity showing events associated with specific I.P. addresses for future analysis and auditing.

This is on top of the existing ability we had already with backup.sh and restore.sh that allows us to do on-demand backup and recovery both within or across regions in the current account or to other accounts entirely.

The original backup system focused on providing fast operational backups and restores for the cluster while taking into account the application logic of OpenEMR to ensure that the restore operation ends with your data restored and OpenEMR up and running. It's also in some ways more flexible than the AWS Backup based system as it allows for the exporting of a backup to another account. AWS Backup also allows for the functionality to export to another account but the requirement is that that target account be a part of the same Organization in AWS Organizations as the originating account. Granting the current backup system permissions to export to or restore to another account is in comparison a matter of IAM permissions in the originating and target account and does not require moving AWS Accounts between organizational units to function better.

For most realistic scenarios I would still recommend using the existing backup and restore system over the AWS Backup system where possible (note that this won’t be possible for anything involving S3 buckets which is outside of the scope of the original backup/restore system) because the restore.sh script was designed to take into account the specific application architecture of OpenEMR to ensure that after a restore operation OpenEMR is operational and you can open up the homepage and log in to the new setup. AWS Backup however is just going to rewind the state of whatever you tell it to to a specific moment in time. I’ll outline an example of when this would be an issue. 

Let’s say you set up the architecture and were using OpenEMR and uploading data to it for two days and then on the third day you changed your RDS password and sqlconf.php file and then shortly after that you had the terminal left open and you went back in accidentally deleted everything on the EFS. You think that should be okay because you have an automatic backup made the day before so you decide to rewind the EFS to the state it was in on day 2 with AWS Backup. After you were finished with this what you’d find is that OpenEMR would just return 500 errors and if you looked at application logs you’d see a lot of failed login attempts to MySQL because now you've restored to a version of sqlconf.php that no longer has valid credentials to access the database. While restore.sh knows that this could be a potential issue and takes this into account when conducting a restore AWS Backup is simply going to rewind components to a given point in time and it’s going to do so without regard for whether or not rewinding the component will actually result in a functionality installation at the end of the process.

Having said all of this it’s still good to have an additional set of backups that provides for point in time recovery, is not beholden to whether or not the cronjob setup to run backup.sh runs successfully and is backed by defined SLAs (https://docs.aws.amazon.com/aws-backup/latest/devguide/aws-backup-limits.html) from AWS.

This PR was tested against the test-end-to-end-backup-restore.sh script and passed.