### PR TITLE
Patch v4.1.5: Bumps Warp to v0.1.1

### DIFF
--- a/scripts/test-warp-pinned-versions.sh
+++ b/scripts/test-warp-pinned-versions.sh
@@ -313,7 +313,7 @@ import os
 # Test converter initialization
 temp_dir = tempfile.mkdtemp()
 try:
-    converter = OMOPToCCDAConverter(data_source=temp_dir, dataset_size='1k')
+    converter = OMOPToCCDAConverter(data_source=temp_dir)
     print('✓ OMOPToCCDAConverter initialized')
     
     # Test gender mapping

--- a/warp/README.md
+++ b/warp/README.md
@@ -7,11 +7,11 @@
 **High-performance direct database import for OpenEMR on EKS - Database access required**
 
 [![CI/CD Tests](https://github.com/openemr/openemr-on-eks/actions/workflows/ci-cd-tests.yml/badge.svg)](https://github.com/jm-openemr-dev-namespace/openemr-on-eks/actions/workflows/ci-cd-tests.yml)
-[![Version](https://img.shields.io/badge/version-0.1.0-blue)](../warp/setup.py#L12)
+[![Version](https://img.shields.io/badge/version-0.1.1-blue)](../warp/setup.py#L12)
 
 </div>
 
-> **⚠️ Beta Status**: Warp is currently in **beta** (version 0.1.0) and should **not be considered production-ready**. While we welcome development contributions and feedback, please use this tool with caution in non-production environments. The project is actively being developed and may undergo significant changes. **Warp will be considered production-ready upon the release of version 1.0.0.**
+> **⚠️ Beta Status**: Warp is currently in **beta** (version 0.1.1) and should **not be considered production-ready**. While we welcome development contributions and feedback, please use this tool with caution in non-production environments. The project is actively being developed and may undergo significant changes. **Warp will be considered production-ready upon the release of version 1.0.0.**
 
 <div align="center">
 
@@ -99,7 +99,6 @@ Warp automatically discovers credentials from Kubernetes secrets or Terraform:
 # No credentials needed - auto-discovered!
 warp ccda_data_upload \
   --data-source s3://synpuf-omop/cmsdesynpuf1k/ \
-  --dataset-size 1k \
   --max-records 100
 ```
 
@@ -113,7 +112,6 @@ warp ccda_data_upload \
   --db-user openemr \
   --db-password password \
   --data-source s3://synpuf-omop/cmsdesynpuf1k/ \
-  --dataset-size 1k \
   --max-records 100
 ```
 
@@ -133,7 +131,6 @@ Warp automatically discovers database credentials from:
 # Auto-discover all credentials
 warp ccda_data_upload \
   --data-source s3://synpuf-omop/cmsdesynpuf1k/ \
-  --dataset-size 1k \
   --max-records 1000
 ```
 
@@ -406,8 +403,6 @@ spec:
         args:
           - "--data-source"
           - "s3://synpuf-omop/cmsdesynpuf1k/"
-          - "--dataset-size"
-          - "1k"
           - "--max-records"
           - "10000"
         resources:
@@ -437,7 +432,6 @@ Uploads patient data to OpenEMR from OMOP format datasets using direct database 
 | `--db-password` | Database password | Auto-discovered |
 | `--db-name` | Database name | openemr |
 | `--data-source` | Data source (S3 path or local directory) | Required |
-| `--dataset-size` | Dataset size (i.e. 1000, 100000, 2300000, etc. etc.) | Required |
 | `--batch-size` | Records per batch | Auto-calculated |
 | `--workers` | Number of parallel workers (for a single task) | CPU count |
 | `--max-records` | Maximum records to process | All records |

--- a/warp/config.example.yaml
+++ b/warp/config.example.yaml
@@ -12,7 +12,6 @@ data_source:
   # OR local path
   # local_path: "/path/to/omop/data"
   
-  dataset_size: "1k"  # Options: 1k, 100k, 2.3m
   aws_region: "us-east-1"
 
 processing:

--- a/warp/k8s-job-benchmark.yaml
+++ b/warp/k8s-job-benchmark.yaml
@@ -55,8 +55,6 @@ spec:
         # Data source configuration - Full dataset benchmark
         - name: DATA_SOURCE
           value: "s3://synpuf-omop/cmsdesynpuf1k/"
-        - name: DATASET_SIZE
-          value: "1k"
         - name: AWS_REGION
           value: "us-west-2"
         
@@ -104,7 +102,6 @@ spec:
             --db-password "$DB_PASSWORD" \
             --db-name "$DB_NAME" \
             --data-source "$DATA_SOURCE" \
-            --dataset-size "$DATASET_SIZE" \
             --batch-size "$BATCH_SIZE" \
             --workers "$WORKERS" \
             --aws-region "$AWS_REGION"

--- a/warp/k8s-job-test.yaml
+++ b/warp/k8s-job-test.yaml
@@ -54,8 +54,6 @@ spec:
         # Data source configuration
         - name: DATA_SOURCE
           value: "s3://synpuf-omop/cmsdesynpuf1k/"
-        - name: DATASET_SIZE
-          value: "1k"
         - name: AWS_REGION
           value: "us-west-2"
         
@@ -101,7 +99,6 @@ spec:
             --db-password \"$DB_PASSWORD\" \
             --db-name \"$DB_NAME\" \
             --data-source \"$DATA_SOURCE\" \
-            --dataset-size \"$DATASET_SIZE\" \
             --batch-size \"$BATCH_SIZE\" \
             --workers \"$WORKERS\" \
             --aws-region \"$AWS_REGION\""

--- a/warp/k8s-job.yaml
+++ b/warp/k8s-job.yaml
@@ -51,8 +51,6 @@ spec:
         # Data source configuration
         - name: DATA_SOURCE
           value: "s3://synpuf-omop/cmsdesynpuf1k/"  # S3 path to OMOP data
-        - name: DATASET_SIZE
-          value: "1k"  # Options: 1k, 100k, 2.3m
         - name: AWS_REGION
           value: "us-west-2"
         
@@ -81,8 +79,6 @@ spec:
         - "$(DB_NAME)"
         - "--data-source"
         - "$(DATA_SOURCE)"
-        - "--dataset-size"
-        - "$(DATASET_SIZE)"
         - "--batch-size"
         - "$(BATCH_SIZE)"
         - "--workers"

--- a/warp/setup.py
+++ b/warp/setup.py
@@ -9,7 +9,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setup(
     name="warp",
-    version="0.1.0",
+    version="0.1.1",
     author="OpenEMR on EKS",
     description="Warp - OpenEMR Data Upload Accelerator",
     long_description=long_description,

--- a/warp/tests/benchmarks/test_performance.py
+++ b/warp/tests/benchmarks/test_performance.py
@@ -26,8 +26,7 @@ def test_ccda_conversion_speed(benchmark):
 
     try:
         converter = OMOPToCCDAConverter(
-            data_source=temp_dir,
-            dataset_size="1k"
+            data_source=temp_dir
         )
 
         person_data = {
@@ -63,8 +62,7 @@ def test_csv_parsing_speed(benchmark):
 
     try:
         converter = OMOPToCCDAConverter(
-            data_source=temp_dir,
-            dataset_size="1k"
+            data_source=temp_dir
         )
 
         csv_content = "person_id,first_name,last_name\n" + \

--- a/warp/tests/test_omop_to_ccda.py
+++ b/warp/tests/test_omop_to_ccda.py
@@ -21,8 +21,7 @@ class TestOMOPToCCDAConverter(unittest.TestCase):
         
         # Create converter with local path
         self.converter = OMOPToCCDAConverter(
-            data_source=self.temp_dir,
-            dataset_size="1k"
+            data_source=self.temp_dir
         )
     
     def tearDown(self):

--- a/warp/warp/__init__.py
+++ b/warp/warp/__init__.py
@@ -2,4 +2,4 @@
 Warp - OpenEMR Data Upload Accelerator
 """
 
-__version__ = "0.1.0"
+__version__ = "0.1.1"

--- a/warp/warp/cli.py
+++ b/warp/warp/cli.py
@@ -29,7 +29,7 @@ Examples:
         """,
     )
 
-    parser.add_argument("--version", action="version", version="%(prog)s 0.1.0")
+    parser.add_argument("--version", action="version", version="%(prog)s 0.1.1")
 
     parser.add_argument(
         "-v", "--verbose", action="store_true", help="Enable verbose logging"

--- a/warp/warp/commands/ccda_data_upload.py
+++ b/warp/warp/commands/ccda_data_upload.py
@@ -65,12 +65,6 @@ class CCDADataUploadCommand:
             required=True,
             help="Data source: S3 path (s3://bucket/path) or local directory",
         )
-        parser.add_argument(
-            "--dataset-size",
-            default="1k",
-            choices=["1k", "100k", "2.3m"],
-            help="Dataset size (default: 1k)",
-        )
 
         # Processing options
         parser.add_argument(
@@ -178,7 +172,6 @@ class CCDADataUploadCommand:
         logger.info("Initializing OMOP to CCDA converter")
         converter = OMOPToCCDAConverter(
             data_source=args.data_source,
-            dataset_size=args.dataset_size,
             aws_region=args.aws_region,
         )
 

--- a/warp/warp/core/omop_to_ccda.py
+++ b/warp/warp/core/omop_to_ccda.py
@@ -26,18 +26,16 @@ class OMOPToCCDAConverter:
     }
 
     def __init__(
-        self, data_source: str, dataset_size: str = "1k", aws_region: str = "us-east-1"
+        self, data_source: str, aws_region: str = "us-east-1"
     ):
         """
         Initialize converter
 
         Args:
             data_source: S3 path (s3://bucket/path) or local directory path
-            dataset_size: Dataset size ('1k', '100k', or '2.3m')
             aws_region: AWS region for S3 access
         """
         self.data_source = data_source
-        self.dataset_size = dataset_size
         self.aws_region = aws_region
         self.s3_client = None
 


### PR DESCRIPTION
Removes unused DATASET_SIZE parameter from Warp. The test dataset only comes in three sizes (1k, 100k or 2.3m) and while the parameter is not used anymore in Warp v0.1.0 I'm removing it because it implies that all downloads have to be of one of those sizes but the actual functionality of Warp is that it will import as much data as it can so long as it is below the value of max-records