### PR TITLE
minor release v4.3.0: removes ingress-nginx support from monitoring s…

### DIFF
--- a/README.md
+++ b/README.md
@@ -657,11 +657,8 @@ export SLACK_WEBHOOK_URL="https://hooks.slack.com/services/..."
 export SLACK_CHANNEL="#openemr-alerts"
 ./install-monitoring.sh
 
-# Optional: Install with ingress and basic auth
-export ENABLE_INGRESS="1"
-export GRAFANA_HOSTNAME="grafana.yourdomain.com"
-export ENABLE_BASIC_AUTH="1"
-./install-monitoring.sh
+# Access monitoring stack via port-forwarding:
+# kubectl port-forward -n monitoring svc/prometheus-stack-grafana 3000:80
 
 # If not using jumpbox, disable access again after monitoring installation
 cd ../scripts
@@ -687,7 +684,7 @@ cd ../scripts
 - 💾 **Optimized Storage**: GP3 with 3000 IOPS for time-series data performance
 - 🔒 **Enhanced Security**: RBAC, network policies, security contexts, encrypted storage, WAFv2 protection
 - 🚀 **Parallel Installation**: Components install simultaneously for faster deployment
-- 🌐 **Optional Ingress**: NGINX ingress with TLS and basic authentication support
+- 🌐 **Port-Forwarding Access**: Secure local access via kubectl port-forward
 - 📋 **Audit Logging**: Audit trails for all monitoring operations
 - ⚙️ **Intelligent Autoscaling**: HPA for all components integrated with EKS Auto Mode
 

--- a/monitoring/README.md
+++ b/monitoring/README.md
@@ -45,7 +45,6 @@ graph TB
     end
 
     subgraph "External Access"
-        ING[NGINX Ingress]
         PF[Port Forward]
     end
 
@@ -56,7 +55,6 @@ graph TB
     LOKI --> GRAF
     JAEG --> GRAF
     PROM --> ALERT
-    ING --> GRAF
     PF --> GRAF
 ```
 
@@ -199,24 +197,6 @@ cd monitoring
 ./install-monitoring.sh
 ```
 
-### Production Installation with Ingress
-
-```bash
-# Configure for production access
-export ENABLE_INGRESS="1"
-export GRAFANA_HOSTNAME="grafana.yourhospital.org"
-export ENABLE_BASIC_AUTH="1"
-
-# Optional: Slack alerting
-export SLACK_WEBHOOK_URL="https://hooks.slack.com/services/..."
-export SLACK_CHANNEL="#openemr-alerts"
-
-# Install (total install time ~8-10 minutes with S3 storage)
-./install-monitoring.sh
-
-# Verify installation
-./install-monitoring.sh verify
-```
 
 ### Access Credentials
 
@@ -379,7 +359,7 @@ export ENABLE_AUTOSCALING="0"     # All components run with minimum replicas
 
 ## 🌐 Access Methods
 
-### Method 1: Port-Forward (Development)
+### Port-Forwarding (Recommended)
 
 ```bash
 # Grafana (primary interface)
@@ -400,21 +380,6 @@ kubectl port-forward -n monitoring svc/loki 3100:3100
 # Access: http://localhost:3100
 ```
 
-### Method 2: NGINX Ingress (Production)
-
-```bash
-# Prerequisites
-# 1. Install NGINX Ingress Controller
-kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/controller-v1.13.1/deploy/static/provider/aws/deploy.yaml
-
-# 2. Configure DNS
-# Point grafana.yourhospital.org to ingress LoadBalancer
-
-# 3. Access
-# URL: https://grafana.yourhospital.org
-# Basic Auth: As configured
-# Grafana Login: admin / <password>
-```
 
 ## 📊 Dashboards
 
@@ -457,14 +422,14 @@ Your Grafana has these data sources pre-configured:
 | Requirement | Implementation | Verification                                                                                                 |
 |-------------|---------------|--------------------------------------------------------------------------------------------------------------|
 | **Encryption at Rest** | GP3 encrypted storage | `kubectl get sc gp3-monitoring-encrypted -o yaml`                                                            |
-| **Encryption in Transit** | TLS 1.2+ for all traffic | Check ingress TLS configuration                                                                              |
+| **Encryption in Transit** | TLS 1.2+ for all traffic | All traffic uses port-forwarding (local access only)                                                                              |
 | **Access Control** | RBAC + Basic Auth + TLS | Review service accounts and secrets                                                                          |
 | **Data Retention** | Configurable retention | Review and confirm configuration allows for necessary retention of data in compliance with relevant policies |
 | **Network Isolation** | NetworkPolicies | `kubectl get networkpolicy -n monitoring`                                                                    |
 
 ### Security Hardening Checklist
 
-- [ ] Enable ingress with TLS only
+- [ ] Use port-forwarding or another secure method for local access
 - [ ] Configure cert-manager for automatic certificate renewal
 - [ ] Set up authentication
 - [ ] Apply NetworkPolicies

--- a/monitoring/openemr-monitoring.conf.example
+++ b/monitoring/openemr-monitoring.conf.example
@@ -42,21 +42,10 @@ BASE_DELAY="30"                 # Base delay between retries (seconds)
 MAX_DELAY="300"                 # Maximum delay between retries (seconds)
 
 # =============================================================================
-# INGRESS CONFIGURATION (optional)
+# ACCESS CONFIGURATION
 # =============================================================================
-# Enable NGINX ingress for external access to Grafana
-ENABLE_INGRESS="0"              # Set to "1" to enable
-
-# Required if ENABLE_INGRESS="1"
-GRAFANA_HOSTNAME=""             # e.g., "grafana.example.com"
-
-# TLS configuration
-TLS_SECRET_NAME=""              # Leave empty for auto-generated self-signed cert
-
-# Basic authentication (only works with NGINX ingress)
-ENABLE_BASIC_AUTH="0"           # Set to "1" to enable
-BASIC_AUTH_USER="admin"         # Basic auth username
-BASIC_AUTH_PASSWORD=""          # Leave empty for auto-generated password
+# Monitoring stack is accessed via port-forwarding (no ingress required)
+# Example: kubectl port-forward -n monitoring svc/prometheus-stack-grafana 3000:80
 
 # =============================================================================
 # ALERTMANAGER SLACK INTEGRATION (optional)
@@ -95,20 +84,15 @@ VALUES_FILE="./prometheus-values.yaml"  # Generated values file
 
 # Development Environment:
 # MONITORING_NAMESPACE="monitoring-dev"
-# ENABLE_INGRESS="0"
 # DEBUG="1"
 
 # Production Environment with Slack:
-# ENABLE_INGRESS="1"
-# GRAFANA_HOSTNAME="grafana.yourdomain.com"
-# ENABLE_BASIC_AUTH="1"
 # SLACK_WEBHOOK_URL="https://hooks.slack.com/services/..."
 # SLACK_CHANNEL="#production-alerts"
 
 # Multi-Tenant Environment:
 # MONITORING_NAMESPACE="monitoring-tenant1"
 # OPENEMR_NAMESPACE="openemr-tenant1"
-# GRAFANA_HOSTNAME="grafana-tenant1.example.com"
 
 # =============================================================================
 # SECURITY NOTES

--- a/monitoring/prometheus-values.yaml
+++ b/monitoring/prometheus-values.yaml
@@ -16,7 +16,7 @@
 # ✅ Sets up comprehensive security contexts and RBAC
 # ✅ Integrates Prometheus, Grafana, Loki, and Jaeger
 # ✅ Configures AlertManager with optional Slack integration
-# ✅ Provides ingress configuration with TLS and basic auth
+# ✅ Provides port-forwarding access for secure local access
 
 # =============================================================================
 # CONFIGURATION OPTIONS
@@ -53,12 +53,6 @@
 # CHART_LOKI_VERSION="6.45.2"                   # Loki stack
 # CHART_JAEGER_VERSION="3.4.1"                  # Jaeger
 
-# Ingress Configuration (optional)
-# ENABLE_INGRESS="0"                            # Enable NGINX ingress
-# GRAFANA_HOSTNAME=""                           # Grafana hostname
-# ENABLE_BASIC_AUTH="0"                         # Enable basic auth
-# BASIC_AUTH_USER="admin"                       # Basic auth username
-# TLS_SECRET_NAME=""                            # TLS secret (auto-generated if empty)
 
 # AlertManager Slack Integration (optional)
 # SLACK_WEBHOOK_URL=""                          # Slack webhook URL
@@ -182,11 +176,9 @@
 # - Detailed audit logging for regulatory compliance
 # - Retry logic with exponential backoff
 
-# 🌐 Optional Ingress:
-# - NGINX ingress with TLS termination
-# - Basic authentication support
-# - Self-signed certificate generation
-# - Custom hostname configuration
+# 🌐 Access Method:
+# - Port-forwarding for secure local access
+# - No external ingress required
 
 # =============================================================================
 # USAGE EXAMPLES
@@ -200,11 +192,8 @@
 # export SLACK_CHANNEL="#alerts"
 # ./install-monitoring.sh
 
-# With ingress and basic auth:
-# export ENABLE_INGRESS="1"
-# export GRAFANA_HOSTNAME="grafana.example.com"
-# export ENABLE_BASIC_AUTH="1"
-# ./install-monitoring.sh
+# Access via port-forwarding:
+# kubectl port-forward -n monitoring svc/prometheus-stack-grafana 3000:80
 
 # Custom autoscaling configuration:
 # export GRAFANA_MAX_REPLICAS="5"

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -521,7 +521,7 @@ This directory contains all the operational scripts for the OpenEMR on EKS deplo
   - Installs comprehensive monitoring stack (Prometheus, Grafana, Loki, Jaeger)
   - Extracts and displays OpenEMR and Grafana login credentials and URLs
   - Supports skipping any deployment step for faster iteration
-  - Optional ingress configuration for Grafana
+  - Port-forwarding access for monitoring stack
   - Comprehensive error handling and progress tracking
 - **Usage**:
   ```bash
@@ -531,8 +531,8 @@ This directory contains all the operational scripts for the OpenEMR on EKS deplo
   # Use existing infrastructure
   ./scripts/quick-deploy.sh --skip-terraform --skip-openemr
 
-  # Enable Grafana ingress
-  ./scripts/quick-deploy.sh --enable-ingress --grafana-hostname grafana.example.com
+  # Access Grafana via port-forwarding
+  kubectl port-forward -n monitoring svc/prometheus-stack-grafana 3000:80
 
   # Custom cluster name or region
   ./scripts/quick-deploy.sh --cluster-name my-cluster --aws-region us-east-1
@@ -543,15 +543,13 @@ This directory contains all the operational scripts for the OpenEMR on EKS deplo
   - `--skip-terraform` - Skip Terraform deployment (use existing infrastructure)
   - `--skip-openemr` - Skip OpenEMR deployment (use existing deployment)
   - `--skip-monitoring` - Skip monitoring installation (use existing monitoring)
-  - `--enable-ingress` - Enable ingress for Grafana (disabled by default)
-  - `--grafana-hostname HOSTNAME` - Hostname for Grafana ingress (e.g., grafana.example.com)
 - **Output**: Prints OpenEMR and Grafana login URLs and credentials at completion
 - **Maintenance Notes**:
   - Script follows the same patterns as other deployment scripts
   - Uses the existing monitoring installation script (`monitoring/install-monitoring.sh`)
   - Automatically configures kubectl and retrieves cluster information from Terraform
   - Validates prerequisites before starting deployment
-  - Provides port-forward instructions if ingress is not enabled
+  - Provides port-forward instructions for accessing monitoring stack
 
 #### `test-config.yaml`
 


### PR DESCRIPTION
…tack

This update removes ingress-nginx from the monitoring stack.

After careful thought this was done because...

1. Port forwarding to an EKS cluster is a secure access method that requires 1/ you have AWS credentials that allow you to set kubeconfig for the target cluster 2/ your Kubernetes user has RBAC permissions to port forward to the monitoring service.

2. Maintaining our own ingress for every additional stack is going to be time consuming. Right now there's only a monitoring stack add-on but there may at some point be a data-science or machine-learning stack. This is especially true given that ingress-nginx was relatively popular until its recent decommissioning announcement and there's no guarantee whatever ingress alternative we migrate to will not be decomissioned at some point. In comparison port forwarding is likely to remain a highly supported feature for as long as Kubernetes is in use.

3. If there ends up being a lot of user demand to re-implement additional ingress methods at some point we can always add one back in in the future.