### PR TITLE
Fix version-check lookups and always run full CI on check-in

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -85,14 +85,15 @@ are synchronized with [`../../versions.yaml`](../../versions.yaml).
 
 ### Workflow Files
 
-- **`ci-cd-tests.yml`** - Main test matrix, validation, Trivy scan, and
-  path-filtered Python project CI
+- **`ci-cd-tests.yml`** - Main test matrix, validation, Trivy scan, Python
+  project CI, and Floci suites (all jobs on every push/PR; suite selection
+  only for manual `workflow_dispatch`)
 - **`ci-contract-tests.yml`** - BATS contracts, version consistency, Terraform,
   kubeconform, TFLint, and full BATS validation
 - **`security-comprehensive.yml`** - Trivy, Checkov, KICS, Bandit, gosec, and
   ShellCheck with zero tolerated unexempted findings
 - **`console-ci.yml`** - Go lint, test, cross-platform builds, and console
-  security scanning
+  security scanning (runs on every push/PR)
 - **`manual-releases.yml`** - Manually authorized semantic releases
 - **`monthly-version-check.yml`** - Monthly dependency awareness and optional
   GitHub issue creation
@@ -124,7 +125,7 @@ graph TD
 
     A --> X[ci-contract-tests.yml]
     A --> Y[security-comprehensive.yml]
-    Z[Console Change] --> AA[console-ci.yml]
+    A --> AA[console-ci.yml]
 
     R[VERSION] --> I
     S[versions.yaml] --> O

--- a/.github/workflows/ci-cd-tests.yml
+++ b/.github/workflows/ci-cd-tests.yml
@@ -72,92 +72,18 @@ env:
   TRIVY_VERSION: '0.72.0'     # Trivy engine version (synced with versions.yaml)
 
 # Checkout/setup v7 actions require Node 24; the GitHub-hosted runners below provide it.
+# Push/PR runs every job. workflow_dispatch may select a single suite.
 jobs:
-  # Detect which Python projects / requirement files changed (skip unrelated CI on push/PR)
-  changes:
-    name: Detect Changed Paths
-    runs-on: ubuntu-26.04
-    outputs:
-      openemr_dr: ${{ steps.filter.outputs.openemr_dr }}
-      warp: ${{ steps.filter.outputs.warp }}
-      credential_rotation: ${{ steps.filter.outputs.credential_rotation }}
-      knowledge_mcp: ${{ steps.filter.outputs.knowledge_mcp }}
-      python_requirements: ${{ steps.filter.outputs.python_requirements }}
-      floci: ${{ steps.filter.outputs.floci }}
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-
-      - name: Detect path changes
-        uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4.0.2
-        id: filter
-        with:
-          filters: |
-            openemr_dr:
-              - 'scripts/openemr_dr/**'
-              - 'scripts/requirements/openemr-dr-dev.txt'
-              - 'scripts/ci/**'
-              - 'scripts/run-dr-tests.sh'
-              - 'scripts/install-python-dev.sh'
-              - 'scripts/validate-python-requirements.sh'
-              - 'scripts/test-openemr-dr-pinned-versions.sh'
-              - 'scripts/restore.sh'
-              - 'versions.yaml'
-            warp:
-              - 'warp/**'
-              - 'scripts/requirements/warp-dev.txt'
-              - 'scripts/test-warp-pinned-versions.sh'
-              - 'scripts/ci/**'
-              - 'scripts/install-python-dev.sh'
-              - 'scripts/validate-python-requirements.sh'
-              - 'versions.yaml'
-            credential_rotation:
-              - 'tools/credential-rotation/**'
-              - 'scripts/requirements/credential-rotation-dev.txt'
-              - 'scripts/test-credential-rotation-pinned-versions.sh'
-              - 'scripts/ci/**'
-              - 'scripts/install-python-dev.sh'
-              - 'scripts/validate-python-requirements.sh'
-              - 'versions.yaml'
-            knowledge_mcp:
-              - 'tools/codebase-mcp/**'
-              - 'docs/KNOWLEDGE_MCP.md'
-              - '.github/workflows/ci-cd-tests.yml'
-              - 'versions.yaml'
-            python_requirements:
-              - 'versions.yaml'
-              - 'scripts/requirements/**'
-              - 'scripts/lib/versions-yq.sh'
-              - 'scripts/lib/python-venv.sh'
-              - 'scripts/validate-python-requirements.sh'
-              - 'scripts/install-python-dev.sh'
-            floci:
-              - 'tests/floci/**'
-              - 'tests/bats/floci*.bats'
-              - 'tests/bats/floci_helper.bash'
-              - 'tests/bats/test-floci-e2e-lite.bats'
-              - 'scripts/run-floci-integration.sh'
-              - 'scripts/test-floci-e2e-lite.sh'
-              - 'scripts/run-test-suite.sh'
-              - 'scripts/test-config.yaml'
-              - 'warp/tests/test_floci_s3.py'
-              - 'tools/credential-rotation/tests/test_floci_secrets.py'
-              - 'scripts/openemr_dr/tests/test_floci_aws.py'
-              - '.github/workflows/ci-cd-tests.yml'
-              - 'versions.yaml'
-
-  # Validate all Python requirement pins when versions.yaml or requirements/ change
+  # Validate all Python requirement pins against versions.yaml
   python-requirements-validate:
     name: Python Requirements Validation
     runs-on: ubuntu-26.04
-    needs: changes
     if: |
-      needs.changes.outputs.python_requirements == 'true' ||
-      (github.event_name == 'workflow_dispatch' &&
-       (github.event.inputs.test_suite == 'all' ||
-        github.event.inputs.test_suite == 'openemr_dr' ||
-        github.event.inputs.test_suite == 'warp' ||
-        github.event.inputs.test_suite == 'credential_rotation'))
+      github.event_name != 'workflow_dispatch' ||
+      github.event.inputs.test_suite == 'all' ||
+      github.event.inputs.test_suite == 'openemr_dr' ||
+      github.event.inputs.test_suite == 'warp' ||
+      github.event.inputs.test_suite == 'credential_rotation'
 
     steps:
       - name: Checkout code
@@ -533,14 +459,13 @@ jobs:
   warp-ci:
     name: Warp CI/CD
     runs-on: ubuntu-26.04
-    needs: changes
     strategy:
       matrix:
         python-version: ['3.10', '3.14.7']
     if: |
-      (github.event_name == 'workflow_dispatch' &&
-       (github.event.inputs.test_suite == 'all' || github.event.inputs.test_suite == 'warp')) ||
-      (github.event_name != 'workflow_dispatch' && needs.changes.outputs.warp == 'true')
+      github.event_name != 'workflow_dispatch' ||
+      github.event.inputs.test_suite == 'all' ||
+      github.event.inputs.test_suite == 'warp'
 
     steps:
       - name: Checkout code
@@ -601,11 +526,10 @@ jobs:
   openemr-dr-ci:
     name: OpenEMR DR Python CI
     runs-on: ubuntu-26.04
-    needs: changes
     if: |
-      (github.event_name == 'workflow_dispatch' &&
-       (github.event.inputs.test_suite == 'all' || github.event.inputs.test_suite == 'openemr_dr')) ||
-      (github.event_name != 'workflow_dispatch' && needs.changes.outputs.openemr_dr == 'true')
+      github.event_name != 'workflow_dispatch' ||
+      github.event.inputs.test_suite == 'all' ||
+      github.event.inputs.test_suite == 'openemr_dr'
 
     steps:
       - name: Checkout code
@@ -645,11 +569,10 @@ jobs:
   credential-rotation-ci:
     name: Credential Rotation CI
     runs-on: ubuntu-26.04
-    needs: changes
     if: |
-      (github.event_name == 'workflow_dispatch' &&
-       (github.event.inputs.test_suite == 'all' || github.event.inputs.test_suite == 'credential_rotation')) ||
-      (github.event_name != 'workflow_dispatch' && needs.changes.outputs.credential_rotation == 'true')
+      github.event_name != 'workflow_dispatch' ||
+      github.event.inputs.test_suite == 'all' ||
+      github.event.inputs.test_suite == 'credential_rotation'
 
     steps:
       - name: Checkout code
@@ -709,11 +632,10 @@ jobs:
   knowledge-mcp-ci:
     name: Knowledge MCP Python CI
     runs-on: ubuntu-26.04
-    needs: changes
     if: |
-      (github.event_name == 'workflow_dispatch' &&
-       (github.event.inputs.test_suite == 'all' || github.event.inputs.test_suite == 'knowledge_mcp')) ||
-      (github.event_name != 'workflow_dispatch' && needs.changes.outputs.knowledge_mcp == 'true')
+      github.event_name != 'workflow_dispatch' ||
+      github.event.inputs.test_suite == 'all' ||
+      github.event.inputs.test_suite == 'knowledge_mcp'
 
     steps:
       - name: Checkout code
@@ -756,12 +678,10 @@ jobs:
   floci-integration:
     name: Floci Integration
     runs-on: ubuntu-26.04
-    needs: changes
     if: |
-      (github.event_name == 'workflow_dispatch' &&
-       (github.event.inputs.test_suite == 'all' ||
-        github.event.inputs.test_suite == 'floci')) ||
-      (github.event_name != 'workflow_dispatch' && needs.changes.outputs.floci == 'true')
+      github.event_name != 'workflow_dispatch' ||
+      github.event.inputs.test_suite == 'all' ||
+      github.event.inputs.test_suite == 'floci'
     env:
       AWS_ENDPOINT_URL: http://localhost:4566
       AWS_DEFAULT_REGION: us-east-1
@@ -824,13 +744,11 @@ jobs:
   floci-e2e-lite:
     name: Floci E2E Lite
     runs-on: ubuntu-26.04
-    needs: changes
     if: |
-      (github.event_name == 'workflow_dispatch' &&
-       (github.event.inputs.test_suite == 'all' ||
-        github.event.inputs.test_suite == 'floci' ||
-        github.event.inputs.test_suite == 'floci_e2e_lite')) ||
-      (github.event_name != 'workflow_dispatch' && needs.changes.outputs.floci == 'true')
+      github.event_name != 'workflow_dispatch' ||
+      github.event.inputs.test_suite == 'all' ||
+      github.event.inputs.test_suite == 'floci' ||
+      github.event.inputs.test_suite == 'floci_e2e_lite'
     env:
       AWS_ENDPOINT_URL: http://localhost:4566
       AWS_DEFAULT_REGION: us-east-1
@@ -885,7 +803,6 @@ jobs:
     name: Test Summary
     runs-on: ubuntu-26.04
     needs:
-      - changes
       - test
       - lint-and-validate
       - security-scan
@@ -913,6 +830,8 @@ jobs:
       # Step 3: Generate comprehensive summary report
       # This step creates a unified view of all test results and job outcomes
       - name: Generate summary report
+        env:
+          EVENT_NAME: ${{ github.event_name }}
         run: |
           echo "## 🧪 CI/CD Test Results Summary"
           echo ""
@@ -939,7 +858,7 @@ jobs:
           if [ "${{ needs.warp-ci.result }}" == "success" ]; then
             echo "✅ **Warp tests passed successfully!**"
           elif [ "${{ needs.warp-ci.result }}" == "skipped" ]; then
-            echo "⏭️ **Warp tests skipped** (no warp files changed or not selected)"
+            echo "⏭️ **Warp tests skipped** (not selected for this manual run)"
           else
             echo "❌ **Warp tests failed or had issues** - Check the warp-ci job logs"
           fi
@@ -949,7 +868,7 @@ jobs:
           if [ "${{ needs.openemr-dr-ci.result }}" == "success" ]; then
             echo "✅ **OpenEMR DR Python tests passed successfully!**"
           elif [ "${{ needs.openemr-dr-ci.result }}" == "skipped" ]; then
-            echo "⏭️ **OpenEMR DR tests skipped** (no openemr_dr files changed or not selected)"
+            echo "⏭️ **OpenEMR DR tests skipped** (not selected for this manual run)"
           else
             echo "❌ **OpenEMR DR tests failed** - Check the openemr-dr-ci job logs"
           fi
@@ -959,7 +878,7 @@ jobs:
           if [ "${{ needs.credential-rotation-ci.result }}" == "success" ]; then
             echo "✅ **Credential rotation tests passed successfully!**"
           elif [ "${{ needs.credential-rotation-ci.result }}" == "skipped" ]; then
-            echo "⏭️ **Credential rotation tests skipped**"
+            echo "⏭️ **Credential rotation tests skipped** (not selected for this manual run)"
           else
             echo "❌ **Credential rotation tests failed** - Check the credential-rotation-ci job logs"
           fi
@@ -969,7 +888,7 @@ jobs:
           if [ "${{ needs.knowledge-mcp-ci.result }}" == "success" ]; then
             echo "✅ **Knowledge MCP tests and uvx verification passed successfully!**"
           elif [ "${{ needs.knowledge-mcp-ci.result }}" == "skipped" ]; then
-            echo "⏭️ **Knowledge MCP tests skipped** (no knowledge MCP files changed or not selected)"
+            echo "⏭️ **Knowledge MCP tests skipped** (not selected for this manual run)"
           else
             echo "❌ **Knowledge MCP tests failed** - Check the knowledge-mcp-ci job logs"
           fi
@@ -979,7 +898,7 @@ jobs:
           if [ "${{ needs.floci-integration.result }}" == "success" ]; then
             echo "✅ **Floci integration suites passed successfully!**"
           elif [ "${{ needs.floci-integration.result }}" == "skipped" ]; then
-            echo "⏭️ **Floci integration skipped** (no Floci-related files changed or not selected)"
+            echo "⏭️ **Floci integration skipped** (not selected for this manual run)"
           else
             echo "❌ **Floci integration failed** - Check the floci-integration job logs"
           fi
@@ -989,7 +908,7 @@ jobs:
           if [ "${{ needs.floci-e2e-lite.result }}" == "success" ]; then
             echo "✅ **Floci e2e-lite scenario passed successfully!**"
           elif [ "${{ needs.floci-e2e-lite.result }}" == "skipped" ]; then
-            echo "⏭️ **Floci e2e-lite skipped** (no Floci-related files changed or not selected)"
+            echo "⏭️ **Floci e2e-lite skipped** (not selected for this manual run)"
           else
             echo "❌ **Floci e2e-lite failed** - Check the floci-e2e-lite job logs"
           fi
@@ -999,7 +918,7 @@ jobs:
           if [ "${{ needs.python-requirements-validate.result }}" == "success" ]; then
             echo "✅ **All Python requirement pins match versions.yaml**"
           elif [ "${{ needs.python-requirements-validate.result }}" == "skipped" ]; then
-            echo "⏭️ **Requirements validation skipped** (versions.yaml unchanged)"
+            echo "⏭️ **Requirements validation skipped** (not selected for this manual run)"
           else
             echo "❌ **Requirements pin validation failed** - Check python-requirements-validate job logs"
           fi
@@ -1007,8 +926,11 @@ jobs:
 
           echo "## 📊 Overall Status"
           OVERALL_OK=true
+          ALLOW_SKIP=false
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            ALLOW_SKIP=true
+          fi
           for job_result in \
-            "${{ needs.changes.result }}" \
             "${{ needs.test.result }}" \
             "${{ needs.lint-and-validate.result }}" \
             "${{ needs.security-scan.result }}" \
@@ -1020,13 +942,21 @@ jobs:
             "${{ needs.knowledge-mcp-ci.result }}" \
             "${{ needs.floci-integration.result }}" \
             "${{ needs.floci-e2e-lite.result }}"; do
-            if [ "$job_result" != "success" ] && [ "$job_result" != "skipped" ]; then
-              OVERALL_OK=false
-              break
+            if [ "$job_result" = "success" ]; then
+              continue
             fi
+            if [ "$ALLOW_SKIP" = true ] && [ "$job_result" = "skipped" ]; then
+              continue
+            fi
+            OVERALL_OK=false
+            break
           done
           if [ "$OVERALL_OK" = true ]; then
-            echo "✅ **All required CI jobs passed or were skipped appropriately!**"
+            if [ "$ALLOW_SKIP" = true ]; then
+              echo "✅ **All required CI jobs passed or were skipped appropriately!**"
+            else
+              echo "✅ **All required CI jobs passed!**"
+            fi
           else
             echo "❌ **Some CI jobs failed. Please review the logs above.**"
           fi
@@ -1039,7 +969,7 @@ jobs:
             echo "- Scanners: Vulnerability, Secret Detection, Configuration"
             echo "- If GitHub Advanced Security is enabled, results are also available in the Security tab"
           elif [ "${{ needs.security-scan.result }}" == "skipped" ]; then
-            echo "⏭️ **Security scan skipped** (not selected for this run)"
+            echo "⏭️ **Security scan skipped** (not selected for this manual run)"
           else
             echo "❌ **Security scan FAILED - Findings detected**"
             echo "- Check the security-scan job logs for detailed vulnerability results"

--- a/.github/workflows/console-ci.yml
+++ b/.github/workflows/console-ci.yml
@@ -5,7 +5,7 @@
 # including building, testing, and linting to ensure code quality.
 #
 # Key Features:
-# - Automatic builds on push and pull requests
+# - Automatic builds on every push and pull request
 # - Go code quality checks (fmt, vet, staticcheck)
 # - Multi-platform builds (macOS, Linux) to verify cross-compilation
 # - Security scanning with Trivy
@@ -17,24 +17,12 @@
 
 name: Console CI/CD
 
-# Workflow triggers
+# Workflow triggers — runs on every check-in (same branch set as other CI)
 on:
-  # Automatic triggers on console changes
   push:
     branches: [ main, develop ]
-    paths:
-      - 'console/**'
-      - '.github/workflows/console-ci.yml'
-      - 'go.mod'
-      - 'go.sum'
   pull_request:
     branches: [ main, develop ]
-    paths:
-      - 'console/**'
-      - '.github/workflows/console-ci.yml'
-      - 'go.mod'
-      - 'go.sum'
-  # Manual trigger
   workflow_dispatch:
 
 # Cancel in-progress runs when a new commit is pushed to the same branch/PR

--- a/docs/DISASTER_RECOVERY_PYTHON.md
+++ b/docs/DISASTER_RECOVERY_PYTHON.md
@@ -104,11 +104,11 @@ Unit pytest runs use `-m "not floci"` so they stay offline. Floci-marked tests
 live in `scripts/openemr_dr/tests/test_floci_aws.py`.
 
 CI jobs **`openemr-dr-ci`**, **`warp-ci`**, **`credential-rotation-ci`**,
-and **`knowledge-mcp-ci`** use path filters so they run only when relevant
-files change. The first three share `scripts/ci/run-python-ci.sh` and
+**`knowledge-mcp-ci`**, and **`python-requirements-validate`** run on every
+push and pull request. Manual `workflow_dispatch` can still select a single
+suite. The first three share `scripts/ci/run-python-ci.sh` and
 `scripts/install-python-dev.sh`; the knowledge MCP uses its locked `uv`
-project. A dedicated **`python-requirements-validate`** job runs when
-`versions.yaml` or `scripts/requirements/` change.
+project.
 
 Shared libraries: `scripts/lib/versions-yq.sh`, `scripts/lib/python-venv.sh`.
 

--- a/docs/TESTING_GUIDE.md
+++ b/docs/TESTING_GUIDE.md
@@ -480,15 +480,17 @@ The CI/CD pipeline automatically runs on:
 
 ### Main CI/CD Jobs
 
-1. **Changed-path detection** - Selects relevant Python project CI and Floci jobs
-2. **Python requirements validation** - Enforces synchronized pins
-3. **Test Matrix** - Runs the four repository test suites in parallel
-4. **Lint and Validate** - Additional validation and linting
-5. **Security Scan** - Trivy scanning with engine version 0.72.0
-6. **Code Quality** - Common issue detection
-7. **Project CI** - Warp, OpenEMR DR, credential rotation, and knowledge MCP
-8. **Floci CI** - Integration suites and e2e-lite against the Floci emulator
-9. **Summary** - Comprehensive results report
+Every push and pull request runs the full job set (manual `workflow_dispatch`
+may still select a single suite):
+
+1. **Python requirements validation** - Enforces synchronized pins
+2. **Test Matrix** - Runs the four repository test suites in parallel
+3. **Lint and Validate** - Additional validation and linting
+4. **Security Scan** - Trivy scanning with engine version 0.72.0
+5. **Code Quality** - Common issue detection
+6. **Project CI** - Warp, OpenEMR DR, credential rotation, and knowledge MCP
+7. **Floci CI** - Integration suites and e2e-lite against the Floci emulator
+8. **Summary** - Comprehensive results report
 
 ### Additional CI Workflows
 
@@ -498,7 +500,7 @@ The CI/CD pipeline automatically runs on:
 - **`security-comprehensive.yml`** - Trivy, Checkov, KICS, Bandit, gosec, and
   ShellCheck; also runs Mondays at 02:00 UTC
 - **`console-ci.yml`** - Go formatting, vet/staticcheck, unit tests,
-  cross-platform builds, and Trivy for console changes
+  cross-platform builds, and Trivy (runs on every push/PR)
 
 **Note**: The security scan runs automatically and displays results in the workflow logs. If GitHub Advanced Security is enabled, results are also uploaded to the Security tab for enhanced vulnerability tracking.
 

--- a/scripts/version-manager.sh
+++ b/scripts/version-manager.sh
@@ -385,6 +385,37 @@ parse_config() {
 
 # Function to get the latest Docker image version from Docker Hub
 # This function queries Docker Hub's API to retrieve the latest available version
+# Newest stable Python 3.minor tag from a Docker Hub tags JSON payload.
+# Matches 3.xx / 3.xx-slim and returns the minor series (e.g. 3.14).
+extract_latest_python_minor_tag() {
+    local response="$1"
+    echo "$response" | jq -r '.results[]?.name // empty' 2>/dev/null \
+        | grep -E '^3\.[0-9]+(-slim)?$' \
+        | sed 's/-slim$//' \
+        | sort -V -r \
+        | head -1 || true
+}
+
+# Classify pinned-vs-latest for awareness checks.
+# Prints: up_to_date | update_available | incomplete
+# Returns 0 for up_to_date/update_available, 1 for incomplete.
+# Matching current and latest must be treated as success (not incomplete).
+classify_version_check_result() {
+    local current="$1"
+    local latest="$2"
+
+    if [ -z "$latest" ]; then
+        echo "incomplete"
+        return 1
+    fi
+    if [ "$latest" = "$current" ]; then
+        echo "up_to_date"
+        return 0
+    fi
+    echo "update_available"
+    return 0
+}
+
 # Extract the newest stable Docker Hub tag from a JSON tags payload.
 # Accepts plain and v-prefixed semver (e.g. 1.6.0, v0.10.0). Architecture
 # suffixes are stripped as a fallback when only arch-qualified tags exist.
@@ -1205,18 +1236,14 @@ EOF
             local python_response=$(curl -s "$python_tags_url" 2>/dev/null || echo "")
             
             if [ -n "$python_response" ] && echo "$python_response" | jq empty 2>/dev/null; then
-                # Extract latest 3.xx version (excluding RC/beta)
-                local python_latest=$(echo "$python_response" | jq -r '.results[].name' 2>/dev/null | \
-                    grep -E "^3\.[0-9]+(-slim)?$" | \
-                    sed 's/-slim$//' | \
-                    sort -V -r | \
-                    head -1 || echo "")
-                
-                if [ -z "$python_latest" ]; then
+                local python_latest
+                python_latest=$(extract_latest_python_minor_tag "$python_response")
+                local python_check_result
+                if ! python_check_result=$(classify_version_check_result "$PYTHON_CURRENT" "$python_latest"); then
                     checks_failed=$((checks_failed + 1))
                     log "ERROR" "Could not determine the latest stable Python Docker image"
                     echo "- **Python Docker Image**: ❌ Version check incomplete" >> "$update_report"
-                elif [ "$python_latest" != "$PYTHON_CURRENT" ]; then
+                elif [ "$python_check_result" = "update_available" ]; then
                     log "INFO" "Python Docker image update available: $PYTHON_CURRENT -> $python_latest"
                     echo "- **Python Docker Image**: $PYTHON_CURRENT → $python_latest (latest 3.xx)" >> "$update_report"
                     search_version_in_codebase "Python Docker Image" "$PYTHON_CURRENT" "$python_latest"

--- a/scripts/version-manager.sh
+++ b/scripts/version-manager.sh
@@ -385,50 +385,82 @@ parse_config() {
 
 # Function to get the latest Docker image version from Docker Hub
 # This function queries Docker Hub's API to retrieve the latest available version
+# Extract the newest stable Docker Hub tag from a JSON tags payload.
+# Accepts plain and v-prefixed semver (e.g. 1.6.0, v0.10.0). Architecture
+# suffixes are stripped as a fallback when only arch-qualified tags exist.
+_extract_latest_docker_semver_tag() {
+    local response="$1"
+    local versions
+
+    versions=$(echo "$response" | jq -r '.results[]?.name // empty' 2>/dev/null \
+        | grep -E '^v?[0-9]+\.[0-9]+\.[0-9]+$' \
+        | sort -V -r) || versions=""
+
+    if [ -z "$versions" ]; then
+        versions=$(echo "$response" \
+            | jq -r '.results[]?.name // empty' 2>/dev/null \
+            | grep -E '^v?[0-9]+\.[0-9]+\.[0-9]+-(amd64|arm64|aarch64|x86_64)$' \
+            | sed -E 's/-(amd64|arm64|aarch64|x86_64)$//' \
+            | sort -V -r \
+            | uniq) || versions=""
+    fi
+
+    echo "$versions" | head -n 1
+}
+
 get_latest_docker_version() {
     local registry="$1" # Docker registry name (e.g., "fluent/fluent-bit")
 
     log "INFO" "Checking latest version for $registry..."
 
-    # Construct Docker Hub API URL for the registry
-    local url="https://registry.hub.docker.com/v2/repositories/${registry}/tags?page_size=100"
-    local response
-    if ! response=$(curl -s "$url"); then
-        log "ERROR" "Failed to fetch tags from Docker Hub for $registry"
-        return 1
-    fi
+    local page=1
+    local max_pages=5
+    local next_url="https://registry.hub.docker.com/v2/repositories/${registry}/tags?page_size=100"
+    local versions=""
+    local response=""
 
-    # Validate that response is valid JSON before parsing
-    if ! echo "$response" | jq empty 2>/dev/null; then
-        log "ERROR" "Invalid JSON response from Docker Hub for $registry. API may be rate-limited or changed."
-        log "DEBUG" "Response preview: $(echo "$response" | head -c 200)..."
-        return 1
-    fi
+    # Paginate: some repos (e.g. otel/ebpf-instrument) bury release tags under
+    # many commit/nightly tags on earlier pages.
+    while [ -n "$next_url" ] && [ "$page" -le "$max_pages" ]; do
+        if ! response=$(curl -sS "$next_url"); then
+            log "ERROR" "Failed to fetch tags from Docker Hub for $registry"
+            return 1
+        fi
 
-    # Parse and filter versions, excluding architecture-specific tags
-    # Only include semantic version numbers (e.g., "7.0.4", not "7.0.4-amd64")
-    local versions=$(echo "$response" | jq -r '.results[].name' | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' | sort -V -r)
+        if ! echo "$response" | jq empty 2>/dev/null; then
+            log "ERROR" "Invalid JSON response from Docker Hub for $registry. API may be rate-limited or changed."
+            log "DEBUG" "Response preview: $(echo "$response" | head -c 200)..."
+            return 1
+        fi
 
-    # Handle case where no clean semantic versions are found
-    if [ -z "$versions" ]; then
-        # If no clean versions found, try to extract base versions from architecture-specific tags
-        # This handles cases where tags include architecture suffixes (e.g., "7.0.4-amd64")
-        local arch_versions
-        arch_versions=$(echo "$response" \
-            | jq -r '.results[].name' \
-            | grep -E '^[0-9]+\.[0-9]+\.[0-9]+-(amd64|arm64|aarch64|x86_64)$' \
-            | sed -E 's/-(amd64|arm64|aarch64|x86_64)$//' \
-            | sort -V -r \
-            | uniq) || arch_versions=""
-        versions="$arch_versions"
-    fi
+        versions=$(_extract_latest_docker_semver_tag "$response")
+        if [ -n "$versions" ]; then
+            echo "$versions"
+            return 0
+        fi
 
-    if [ -z "$versions" ]; then
-        log "ERROR" "No stable semantic-version tags found for $registry"
-        return 1
-    fi
+        next_url=$(echo "$response" | jq -r '.next // empty' 2>/dev/null || echo "")
+        page=$((page + 1))
+    done
 
-    echo "$versions" | head -n 1
+    # Targeted search when release tags never appear in the first pages.
+    for name_filter in v 0 1 2 3 4 5 6 7 8 9; do
+        local filter_url="https://registry.hub.docker.com/v2/repositories/${registry}/tags?page_size=100&name=${name_filter}"
+        if ! response=$(curl -sS "$filter_url"); then
+            continue
+        fi
+        if ! echo "$response" | jq empty 2>/dev/null; then
+            continue
+        fi
+        versions=$(_extract_latest_docker_semver_tag "$response")
+        if [ -n "$versions" ]; then
+            echo "$versions"
+            return 0
+        fi
+    done
+
+    log "ERROR" "No stable semantic-version tags found for $registry"
+    return 1
 }
 
 # Return the latest official non-draft, non-prerelease OpenEMR release.
@@ -1180,15 +1212,17 @@ EOF
                     sort -V -r | \
                     head -1 || echo "")
                 
-                if [ -n "$python_latest" ] && [ "$python_latest" != "$PYTHON_CURRENT" ]; then
+                if [ -z "$python_latest" ]; then
+                    checks_failed=$((checks_failed + 1))
+                    log "ERROR" "Could not determine the latest stable Python Docker image"
+                    echo "- **Python Docker Image**: ❌ Version check incomplete" >> "$update_report"
+                elif [ "$python_latest" != "$PYTHON_CURRENT" ]; then
                     log "INFO" "Python Docker image update available: $PYTHON_CURRENT -> $python_latest"
                     echo "- **Python Docker Image**: $PYTHON_CURRENT → $python_latest (latest 3.xx)" >> "$update_report"
                     search_version_in_codebase "Python Docker Image" "$PYTHON_CURRENT" "$python_latest"
                     updates_found=1
                 else
-                    checks_failed=$((checks_failed + 1))
-                    log "ERROR" "Could not determine the latest stable Python Docker image"
-                    echo "- **Python Docker Image**: ❌ Version check incomplete" >> "$update_report"
+                    log "INFO" "Python Docker image is up to date: $PYTHON_CURRENT"
                 fi
             else
                 checks_failed=$((checks_failed + 1))

--- a/tests/bats/test_helper.bash
+++ b/tests/bats/test_helper.bash
@@ -84,6 +84,22 @@ extract_function() {
   echo "$tmp"
 }
 
+# Extract multiple functions into one sourcable temp file (for helpers that
+# call each other, e.g. get_latest_docker_version + _extract_latest_docker_semver_tag).
+extract_functions() {
+  local script="$1"
+  shift
+  local tmp part fn
+  tmp=$(mktemp "${BATS_TEST_TMPDIR:-/tmp}/bats_funcs_XXXXXX.bash")
+  : >"$tmp"
+  for fn in "$@"; do
+    part=$(extract_function "$script" "$fn")
+    cat "$part" >>"$tmp"
+    rm -f "$part"
+  done
+  echo "$tmp"
+}
+
 # ---------------------------------------------------------------------------
 # Temp fixture helpers — create disposable files/dirs for tests that need
 # to control the filesystem (e.g., providing a custom versions.yaml).

--- a/tests/bats/version-manager.bats
+++ b/tests/bats/version-manager.bats
@@ -258,7 +258,7 @@ SCRIPT="${SCRIPTS_DIR}/version-manager.sh"
 
 @test "UNIT: Docker stable lookup returns newest clean semantic version" {
   if ! command -v jq >/dev/null 2>&1; then skip "jq not installed"; fi
-  FUNC_FILE=$(extract_function "$SCRIPT" "get_latest_docker_version")
+  FUNC_FILE=$(extract_functions "$SCRIPT" "_extract_latest_docker_semver_tag" "get_latest_docker_version")
   run bash -c '
     log() { :; }
     curl() {
@@ -274,11 +274,11 @@ SCRIPT="${SCRIPTS_DIR}/version-manager.sh"
 
 @test "UNIT: Docker stable lookup does not reinterpret prerelease tags" {
   if ! command -v jq >/dev/null 2>&1; then skip "jq not installed"; fi
-  FUNC_FILE=$(extract_function "$SCRIPT" "get_latest_docker_version")
+  FUNC_FILE=$(extract_functions "$SCRIPT" "_extract_latest_docker_semver_tag" "get_latest_docker_version")
   run bash -c '
     log() { :; }
     curl() {
-      printf "%s\n" '"'"'{"results":[{"name":"8.3.0-rc1"},{"name":"latest"}]}'"'"'
+      printf "%s\n" '"'"'{"next":null,"results":[{"name":"8.3.0-rc1"},{"name":"latest"}]}'"'"'
     }
     source "$1"
     get_latest_docker_version "fluent/fluent-bit"
@@ -286,6 +286,125 @@ SCRIPT="${SCRIPTS_DIR}/version-manager.sh"
   rm -f "$FUNC_FILE"
   assert_failure
   [ -z "$output" ]
+}
+
+@test "UNIT: Docker stable lookup accepts v-prefixed semver tags" {
+  if ! command -v jq >/dev/null 2>&1; then skip "jq not installed"; fi
+  FUNC_FILE=$(extract_functions "$SCRIPT" "_extract_latest_docker_semver_tag" "get_latest_docker_version")
+  run bash -c '
+    log() { :; }
+    curl() {
+      printf "%s\n" '"'"'{"results":[{"name":"v0.4.1"},{"name":"v0.10.0"},{"name":"latest"},{"name":"main"}]}'"'"'
+    }
+    source "$1"
+    get_latest_docker_version "otel/ebpf-instrument"
+  ' _ "$FUNC_FILE"
+  rm -f "$FUNC_FILE"
+  assert_success
+  [ "$output" = "v0.10.0" ]
+}
+
+@test "UNIT: Docker stable lookup paginates past commit and nightly tags" {
+  if ! command -v jq >/dev/null 2>&1; then skip "jq not installed"; fi
+  FUNC_FILE=$(extract_functions "$SCRIPT" "_extract_latest_docker_semver_tag" "get_latest_docker_version")
+  run bash -c '
+    log() { :; }
+    curl() {
+      # Command substitution runs curl in a subshell; key off the URL, not a counter.
+      local url="${*: -1}"
+      if [[ "$url" == *page=2* ]]; then
+        printf "%s\n" '"'"'{"next":null,"results":[{"name":"v0.9.0"},{"name":"v0.10.0"},{"name":"nightly-20260810"}]}'"'"'
+      else
+        printf "%s\n" '"'"'{"next":"https://registry.hub.docker.com/v2/repositories/otel/ebpf-instrument/tags?page=2&page_size=100","results":[{"name":"deadbeef"},{"name":"nightly"},{"name":"main"}]}'"'"'
+      fi
+    }
+    source "$1"
+    get_latest_docker_version "otel/ebpf-instrument"
+  ' _ "$FUNC_FILE"
+  rm -f "$FUNC_FILE"
+  assert_success
+  [ "$output" = "v0.10.0" ]
+}
+
+@test "UNIT: Docker stable lookup falls back to name-filtered tag search" {
+  if ! command -v jq >/dev/null 2>&1; then skip "jq not installed"; fi
+  FUNC_FILE=$(extract_functions "$SCRIPT" "_extract_latest_docker_semver_tag" "get_latest_docker_version")
+  run bash -c '
+    log() { :; }
+    curl() {
+      local url="${*: -1}"
+      if [[ "$url" == *name=v* ]]; then
+        printf "%s\n" '"'"'{"next":null,"results":[{"name":"v0.10.0"},{"name":"v0.4.1"}]}'"'"'
+      else
+        printf "%s\n" '"'"'{"next":null,"results":[{"name":"deadbeef"},{"name":"nightly"},{"name":"main"}]}'"'"'
+      fi
+    }
+    source "$1"
+    get_latest_docker_version "otel/ebpf-instrument"
+  ' _ "$FUNC_FILE"
+  rm -f "$FUNC_FILE"
+  assert_success
+  [ "$output" = "v0.10.0" ]
+}
+
+@test "UNIT: extract_latest_python_minor_tag prefers newest 3.xx series" {
+  if ! command -v jq >/dev/null 2>&1; then skip "jq not installed"; fi
+  FUNC_FILE=$(extract_function "$SCRIPT" "extract_latest_python_minor_tag")
+  run bash -c '
+    source "$1"
+    extract_latest_python_minor_tag '"'"'{"results":[{"name":"3.13.15"},{"name":"3.14-slim"},{"name":"3.14"},{"name":"3.14.7-slim"},{"name":"3.15.0rc1"}]}'"'"'
+  ' _ "$FUNC_FILE"
+  rm -f "$FUNC_FILE"
+  assert_success
+  [ "$output" = "3.14" ]
+}
+
+@test "UNIT: classify_version_check_result treats matching versions as up to date" {
+  FUNC_FILE=$(extract_function "$SCRIPT" "classify_version_check_result")
+  run bash -c '
+    source "$1"
+    classify_version_check_result "3.14" "3.14"
+  ' _ "$FUNC_FILE"
+  rm -f "$FUNC_FILE"
+  assert_success
+  [ "$output" = "up_to_date" ]
+}
+
+@test "UNIT: classify_version_check_result reports update_available for newer latest" {
+  FUNC_FILE=$(extract_function "$SCRIPT" "classify_version_check_result")
+  run bash -c '
+    source "$1"
+    classify_version_check_result "3.13" "3.14"
+  ' _ "$FUNC_FILE"
+  rm -f "$FUNC_FILE"
+  assert_success
+  [ "$output" = "update_available" ]
+}
+
+@test "UNIT: classify_version_check_result reports incomplete when latest is empty" {
+  FUNC_FILE=$(extract_function "$SCRIPT" "classify_version_check_result")
+  run bash -c '
+    source "$1"
+    classify_version_check_result "3.14" ""
+  ' _ "$FUNC_FILE"
+  rm -f "$FUNC_FILE"
+  assert_failure
+  [ "$output" = "incomplete" ]
+}
+
+@test "UNIT: Python Docker image check does not fail when already current" {
+  if ! command -v jq >/dev/null 2>&1; then skip "jq not installed"; fi
+  FUNC_FILE=$(extract_functions "$SCRIPT" "extract_latest_python_minor_tag" "classify_version_check_result")
+  run bash -c '
+    source "$1"
+    payload='"'"'{"results":[{"name":"3.14"},{"name":"3.14-slim"},{"name":"3.13"},{"name":"3.14.7"}]}'"'"'
+    latest=$(extract_latest_python_minor_tag "$payload")
+    result=$(classify_version_check_result "3.14" "$latest")
+    [ "$latest" = "3.14" ]
+    [ "$result" = "up_to_date" ]
+  ' _ "$FUNC_FILE"
+  rm -f "$FUNC_FILE"
+  assert_success
 }
 
 @test "UNIT: OpenEMR lookup trusts official releases instead of newer Docker tags" {

--- a/versions.yaml
+++ b/versions.yaml
@@ -232,14 +232,6 @@ github_workflows:
     requires_aws_cli: false
     description: "Runs JavaScript in GitHub Actions workflows."
 
-  paths_filter:
-    current: "v4.0.2"
-    repository: "dorny/paths-filter"
-    sha: "7b450fff21473bca461d4b92ce414b9d0420d706"
-    notify_on_update: true
-    requires_aws_cli: false
-    description: "Selects CI jobs based on changed repository paths."
-
   setup_tflint:
     current: "v6.3.0"
     repository: "terraform-linters/setup-tflint"


### PR DESCRIPTION
## Summary
- Fix Python Docker image awareness treating an unchanged `3.xx` tag as a failed lookup (root cause of the incomplete check in [run 31431894558](https://github.com/openemr/openemr-on-eks/actions/runs/31431894558)).
- Teach Docker Hub version lookup to accept `v`-prefixed semver tags, paginate past commit/nightly noise, and fall back to name-filtered tag searches so `otel/ebpf-instrument` resolves.
- Add BATS regression coverage for those lookup/classification paths.
- Run the full CI suite on every push/PR: remove `dorny/paths-filter` job gating and Console CI path filters; keep suite selection for manual `workflow_dispatch` only.

## Test plan
- [x] `./scripts/version-manager.sh check --components applications` → Python Docker image reported up to date (`3.14`)
- [x] `./scripts/version-manager.sh check --components monitoring` → OTeBPF resolves (`v0.4.1` → `v0.10.0`) instead of incomplete
- [x] `bats tests/bats/version-manager.bats` → 47/47 pass
- [x] Confirm PR checks run Warp, OpenEMR DR, Floci, Console, and requirements validation even when those paths are unchanged
- [ ] Re-run **Version Check & Awareness** (`workflow_dispatch`) after merge